### PR TITLE
Let server respect ThreadPool.alive, pass settings to Plugin

### DIFF
--- a/snaketalk/bot.py
+++ b/snaketalk/bot.py
@@ -44,7 +44,7 @@ class Bot:
 
     def _initialize_plugins(self, plugins: Sequence[Plugin]):
         for plugin in plugins:
-            plugin.initialize(self.driver)
+            plugin.initialize(self.driver, self.settings)
         return plugins
 
     def run(self):

--- a/snaketalk/plugins/base.py
+++ b/snaketalk/plugins/base.py
@@ -9,6 +9,7 @@ from typing import Dict, Sequence
 from snaketalk.driver import Driver
 from snaketalk.function import MessageFunction, listen_to
 from snaketalk.message import Message
+from snaketalk.settings import Settings
 
 
 class Plugin(ABC):
@@ -22,12 +23,14 @@ class Plugin(ABC):
 
     def __init__(self):
         self.driver = None
+        self.settings = None
         self.message_listeners: Dict[
             re.Pattern, Sequence[MessageFunction]
         ] = defaultdict(list)
 
-    def initialize(self, driver: Driver):
+    def initialize(self, driver: Driver, settings: Settings = Settings()):
         self.driver = driver
+        self.settings = settings
 
         # Register listeners for any listener functions we might have
         for attribute in dir(self):

--- a/snaketalk/plugins/webhook_example.py
+++ b/snaketalk/plugins/webhook_example.py
@@ -1,3 +1,4 @@
+from snaketalk.driver import Driver
 from snaketalk.message import Message
 from snaketalk.plugins.base import Plugin, listen_to
 from snaketalk.settings import Settings
@@ -6,16 +7,16 @@ from snaketalk.settings import Settings
 class WebhookExample(Plugin):
     """Webhook plugin with examples of webhook server functionality."""
 
-    def __init__(self):
-        super().__init__()
-        self.webhook_host_url = Settings().WEBHOOK_HOST_URL
-        self.webhook_host_port = Settings().WEBHOOK_HOST_PORT
-        self.webhook_id = Settings().WEBHOOK_ID
+    def initialize(self, driver: Driver, settings: Settings):
+        super().initialize(driver, settings)
+        self.webhook_host_url = self.settings.WEBHOOK_HOST_URL
+        self.webhook_host_port = self.settings.WEBHOOK_HOST_PORT
+        self.webhook_id = self.settings.WEBHOOK_ID
         self.webhook_url = self._make_webhook_url()
 
     def _make_webhook_url(self):
-        mattermost_url = Settings().MATTERMOST_URL
-        mattermost_port = Settings().MATTERMOST_PORT
+        mattermost_url = self.settings.MATTERMOST_URL
+        mattermost_port = self.settings.MATTERMOST_PORT
         webhook_url = (
             f"http://{mattermost_url}:{mattermost_port}/hooks/{self.webhook_id}"
         )

--- a/snaketalk/settings.py
+++ b/snaketalk/settings.py
@@ -18,7 +18,7 @@ class Settings:
     WEBHOOK_HOST_ENABLED: bool = True
     WEBHOOK_HOST_URL: str = "http://127.0.0.1"
     WEBHOOK_HOST_PORT: int = 8579
-    WEBHOOK_ID: str = "webhook_id"
+    WEBHOOK_ID: str = "eauegoqk4ibxigfybqrsfmt48r"
     DEBUG: bool = False
     IGNORE_USERS: Sequence[str] = field(default_factory=list)
     # How often to check whether any scheduled jobs need to be run, default every second

--- a/snaketalk/settings.py
+++ b/snaketalk/settings.py
@@ -17,8 +17,8 @@ class Settings:
     SSL_VERIFY: bool = True
     WEBHOOK_HOST_ENABLED: bool = True
     WEBHOOK_HOST_URL: str = "http://127.0.0.1"
-    WEBHOOK_HOST_PORT: int = 8080
-    WEBHOOK_ID: str = ""
+    WEBHOOK_HOST_PORT: int = 8579
+    WEBHOOK_ID: str = "webhook_id"
     DEBUG: bool = False
     IGNORE_USERS: Sequence[str] = field(default_factory=list)
     # How often to check whether any scheduled jobs need to be run, default every second

--- a/snaketalk/threadpool.py
+++ b/snaketalk/threadpool.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import queue
 import threading
@@ -73,9 +74,11 @@ class ThreadPool(object):
         self.add_task(run_pending)
 
     def start_webhook_server_thread(self):
-        def start_server():
+        async def start_server():
             logging.info("Webhook server thread started.")
+            await self.webhook_server.start()
             while self.alive:
-                self.webhook_server.start()
+                # We just use this to keep the loop running in a non-blocking way
+                await asyncio.sleep(0.001)
 
-        self.add_task(start_server)
+        self.add_task(asyncio.run, start_server())

--- a/snaketalk/webhook_server.py
+++ b/snaketalk/webhook_server.py
@@ -54,17 +54,13 @@ class WebhookServer:
         self.app.add_routes(routes)
         self.settings = Settings()
 
-    async def runner(self):
+    async def start(self):
         webhook_host_ip = self.settings.WEBHOOK_HOST_URL.replace("http://", "")
         await self.app_runner.setup()
         site = web.TCPSite(
             self.app_runner, webhook_host_ip, self.settings.WEBHOOK_HOST_PORT
         )
         await site.start()
-        await asyncio.Event().wait()
-
-    def start(self):
-        asyncio.run(self.runner())
 
     def stop(self):
         self.app_runner.cleanup()

--- a/tests/integration_tests/README.md
+++ b/tests/integration_tests/README.md
@@ -1,4 +1,5 @@
 To locally run the integration test, first install `docker-compose` and then simply run `docker-compose up -d` from this folder.
 The server will be available at `localhost:8065`, if you want to have a look at it.
-Once the server is running, simply run `pytest .` to run the tests.
+The admin login is `admin@admin.com` with password `admin`.
+Once the server is running, simply run `pytest . -n auto` to run the tests.
 Once you're done, stop the server with `docker-compose down`.

--- a/tests/unit_tests/function_test.py
+++ b/tests/unit_tests/function_test.py
@@ -4,7 +4,7 @@ from unittest import mock
 import click
 import pytest
 
-from snaketalk import ExamplePlugin, MessageFunction, listen_to
+from snaketalk import ExamplePlugin, MessageFunction, Settings, listen_to
 from snaketalk.driver import Driver
 
 from .message_handler_test import create_message
@@ -106,7 +106,7 @@ class TestMessageFunction:
             assert "no such option: --nonexistent-arg" in response
             assert f.docstring in response
 
-        f.plugin = ExamplePlugin().initialize(Driver())
+        f.plugin = ExamplePlugin().initialize(Driver(), Settings())
         with mock.patch.object(
             f.plugin.driver, "reply_to", wraps=mocked_reply
         ) as mock_function:


### PR DESCRIPTION
I've made some minor modifications to the webhook server code so that it no longer blocks forever (hence requiring a force-stop to kill the thread). By sleeping for some minor amount of time (which, if I understand correctly, should not block the actual server loop), we can check whether the webhook server should be closed or not.

I've also changed the default webhook id (to correspond to the webhook that is actually registered on the CI server) and server port, which should hopefully fix those CI errors, and have changed `Plugin.initialize` to also take a `Settings` object, so that the settings are now available to all plugins.